### PR TITLE
fix(package.json): fixed 'Unable to find plugin'

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,7 @@
 npm
-dist
 build
 coverage
 node_modules
+index.js
+utils.js
+gatsby-node.js

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 # Text editor files #
 #####################
 .idea
+*.iml
 .classpath
 .project
 .settings
@@ -69,7 +70,6 @@ pids
 
 # Folders #
 ###########
-dist
 build
 lib-cov
 coverage
@@ -78,3 +78,5 @@ coverage
 #########
 /index.js
 /gatsby-ssr.js
+/utils.js
+/gatsby-node.js

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   "bugs": {
     "url": "https://github.com/weirdpattern/gatsby-remark-series-toc/issues"
   },
-  "main": "dist/index.js",
+  "main": "index.js",
   "files": [
-    "dist"
+    "index.js",
+    "gatsby-node.js",
+    "utils.js"
   ],
   "keywords": [
     "gatsby",
@@ -30,8 +32,9 @@
     "plugin"
   ],
   "scripts": {
-    "build": "rimraf dist && babel src --out-dir dist",
-    "clean": "npx rimraf node_modules dist build",
+    "clean-dist": "npx rimraf index.js utils.js gatsby-node.js",
+    "build": "yarn run clean-dist && babel src --out-dir .",
+    "clean": "yarn run clean-dist && npx rimraf node_modules build",
     "commit": "commit",
     "format": "prettier --write '*.{js,jsx,md}'",
     "lint": "eslint . --ext .js,.jsx",


### PR DESCRIPTION
This is a fix for the following issue: https://github.com/weirdpattern/gatsby-remark-series/issues/2

It looks like plugins now cannot have their files in a nested folder, instead, they need to be on the root level.

See this issue: https://github.com/gatsbyjs/gatsby/issues/14068

You can easily verify that this is the case. In your `node_modules` find the plugin folder and just move everything from `dist` to the root of the plugin directory.

So my changes are:
1. Build now outputs to the root directory instead of dist
2. Cleaning of files before the build and with dedicated clean action now deletes files individually instead of `dist` folder
3. Updated `gitignore` and `eslintignore` to match individual files instead of `dist`
