### PR TITLE
Fix runtime TypeError in GatsbyNode

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -81,7 +81,7 @@ export function onCreateNode(
     // by setting a random contentDigest
     for (const sibling of siblings) {
       sibling.internal.contentDigest = createContentDigest(
-        new Date().getTime()
+        new Date().getTime().toString()
       );
 
       touched[series].add(sibling.internal.contentDigest);


### PR DESCRIPTION
Previously, when running the plugin on the newest version of Gatsby, I'd get the following error during `gatsby develop`:

```
 ERROR #11321  PLUGIN

"gatsby-remark-series" threw an error while running the onCreateNode lifecycle:

The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (1585508258251)

  89 |       ) {
  90 |         const sibling = _step.value;
> 91 |         sibling.internal.contentDigest = createContentDigest(
     |                                          ^
  92 |           new Date().getTime()
  93 |         );
  94 |         touched[series].add(sibling.internal.contentDigest);

File: node_modules\gatsby-remark-series\gatsby-node.js:91:42



  Error: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (1585508258251)
```

This PR fixes that error and makes the plugin usable again for newer versions of Gatsby